### PR TITLE
add existing group to group

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The configuration object should be stored within a file, then before invoking th
 - Removing a group from a OU (See restriction below)
 - Add a user to a group
 - Removing a user from a group
+- Adding existing group, a group outside of the current ADM process, to a group
 
 ## Restrictions
 
@@ -76,6 +77,12 @@ $configObject = @{
         UserName = "user3"
     }
   }
+  Groups = @{
+    Group1 = @{
+      # Find the account you were interested in, copy the distinguishedName, which includes the DC identity
+      DistinguishedName = "CN=GroupName,OU=OtherACG,OU=UPA,DC=subdomain2,DC=domain,DC=com"
+    }
+  }
   OUStructure = @(
     @{
       Name   = "SC"
@@ -85,11 +92,14 @@ $configObject = @{
           Name   = "DevTeam"
           Groups = @( # Array of groups to be in this OU
             @{
-              Name  = "ProjectAdmins" # Name of Group
+              Name  = "ProjectAdmins" # Name of Group              
               Users = @( 
                   $configData.Users.User1 # subdomain account
                   $configData.Users.User2 # subdomain2 account
                   $configData.Users.User3 # subdomain account
+              )
+              Groups = @(
+                $configData.Groups.Group1
               )
             }
           )

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ A full example of an configuration object and invocation is below, the configura
   - Settings allows you to set a `GroupPrefix` and `Environment` if needed.
 - `Domain` (Array)
 - `Users` (Hashtable)
+- `Groups` (Hashtable)
+  - Groups are ADGroups that exist enternally to the `$configData`
+  - You are require to add the `DistinguishedName` of the ADGroup you wish to link
 - `OUStructure` (Array)
 
 The `Domain.Credential` property could be provided with a `Get-Credential`, There is a function `Get-ADAccount` this currently calls `Get-Credential`, but could be backed with PMP.

--- a/UKHO.ADM.Tests/internal/Get-NonADMGeneratedGroup.Tests.ps1
+++ b/UKHO.ADM.Tests/internal/Get-NonADMGeneratedGroup.Tests.ps1
@@ -1,0 +1,34 @@
+InModuleScope $mut {
+    Describe "Get-NonADMGeneratedGroup" {
+        $domain = [ADDomain]::new("subdomain.fakedomain.com", "server1.subdomain.fakedomain.com", $false, "DC=subdomain,DC=fakedomain,DC=com", $cred)
+        $ou = [ADOrganisationalUnit]::new("UKHO", "OU=SC,OU=ACG,OU=UPA,DC=subdomain,DC=fakedomain,DC=com", $domain)
+        $group = [ADGroup]::new("DevTeam", "LIVE", "SC", "Readers", "GG", "OU=DevTeam,OU=UKHO,OU=SC,OU=ACG,OU=UPA,DC=subdomain,DC=fakedomain,DC=com", $domain) 
+    
+        Context "When passed a group is in same domain" {
+            $groupConfig = @{Settings = @{ GroupPrefix = "Noo" }; Name = "Foo"; Groups = @(@{DistinguishedName = "CN=Hello,DC=subdomain,DC=fakedomain,DC=com"}); }
+            
+            Mock Check-GroupExists { return $true }
+
+            Get-NonADMGeneratedGroup -OU $ou -GroupConfig $groupConfig -ggGroup $group
+            
+            It "Calls Check-GroupExists" {
+                Assert-MockCalled Check-GroupExists -Times 1
+            }
+
+        }
+
+        
+        Context "When passed a group is in different domain" {            
+            $groupConfig = @{Settings = @{ GroupPrefix = "Noo" }; Name = "Foo"; Groups = @(@{DistinguishedName = "CN=Hello,DC=subdomain1,DC=fakedomain,DC=com"}); }
+
+            Mock Check-GroupExists { return $true }
+
+            Get-NonADMGeneratedGroup -OU $ou -GroupConfig $groupConfig -ggGroup $group
+            
+            It "Does not call Check-GroupExists" {
+                Assert-MockCalled Check-GroupExists -Times 0
+            }
+
+        }
+    }
+}

--- a/UKHO.ADM/Objects/Objects.ps1
+++ b/UKHO.ADM/Objects/Objects.ps1
@@ -32,13 +32,23 @@ class ADGroup {
         $this.ADGroupMembers = @()
         $this.UserAccountMembers = @()
         $this.Domain = $domain
+        $this.ADMGenerated = $true
     }
+
+    ADGroup([string]$DistinguishedName, [ADDomain]$domain) {
+        $this.DistinguishedName = $distinguishedName
+        $this.Name = $this.DistinguishedName.Split(',')[0].Replace("CN=","")
+        $this.Domain = $domain
+        $this.ADMGenerated = $false
+    }
+
     
     [string]$Name
     [ADUserAccount[]]$UserAccountMembers
     [ADGroup[]]$ADGroupMembers
     [string]$DistinguishedName
     [ADDomain] $Domain
+    [bool]$ADMGenerated
 
 }
 

--- a/UKHO.ADM/UKHO.ADM.psd1
+++ b/UKHO.ADM/UKHO.ADM.psd1
@@ -12,7 +12,7 @@
     RootModule = 'UKHO.ADM.psm1'
     
     # Version number of this module.
-    ModuleVersion = '3.0.3'
+    ModuleVersion = '4.0.0'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -108,6 +108,7 @@
     
             # ReleaseNotes of this module
             ReleaseNotes = '
+            4.0) Add GroupMembers to Group
             3.0.3) bugfix Getting groups from OU level
             3.0.2) bugfix of ADGroup Smash
             3.0) Credential added to domain

--- a/UKHO.ADM/internal/ConvertTo-GroupObjects.ps1
+++ b/UKHO.ADM/internal/ConvertTo-GroupObjects.ps1
@@ -20,7 +20,7 @@ function ConvertTo-GroupObjects {
                 $ggGroup = [ADGroup]::new($Settings.GroupPrefix, $Settings.Environment, $OU.Name, $GroupConfig.Name, "GG", $OU.DistinguishedName, $OU.Domain)
                 $dlGroup.ADGroupMembers += $ggGroup
 
-                # Add Other Groups
+                # Adds groups that exist externally from configData
                 Get-NonADMGeneratedGroup -OU $OU -GroupConfig $GroupConfig -ggGroup $ggGroup
 
                 $groups += $dlGroup
@@ -31,7 +31,7 @@ function ConvertTo-GroupObjects {
                 $ggGroup = [ADGroup]::new($Settings.GroupPrefix, $Settings.Environment, $OU.Name, $GroupConfig.Name, "GG", $OU.DistinguishedName, $OU.Domain)
                 $ugGroup.ADGroupMembers += $ggGroup
 
-                # Add Other Groups
+                # Adds groups that exist externally from configData
                 Get-NonADMGeneratedGroup -OU $OU -GroupConfig $GroupConfig -ggGroup $ggGroup
 
                 $groups += $ugGroup

--- a/UKHO.ADM/internal/ConvertTo-GroupObjects.ps1
+++ b/UKHO.ADM/internal/ConvertTo-GroupObjects.ps1
@@ -20,6 +20,16 @@ function ConvertTo-GroupObjects {
                 $ggGroup = [ADGroup]::new($Settings.GroupPrefix, $Settings.Environment, $OU.Name, $GroupConfig.Name, "GG", $OU.DistinguishedName, $OU.Domain)
                 $dlGroup.ADGroupMembers += $ggGroup
 
+                # Add Other Groups
+                if ($null -ne $GroupConfig.Groups -and $GroupConfig.Groups.Count -gt 0) {
+                    $GroupConfig.Groups | ForEach-Object {
+                        $groupGroup = [ADGroup]::new($_.DistinguishedName, $OU.Domain)
+                        if (Check-GroupExists $groupGroup) {
+                            $dlGroup.ADGroupMembers += $groupGroup
+                        }
+                    }
+                }
+
                 $groups += $dlGroup
                 $groups += $ggGroup
             }
@@ -28,16 +38,27 @@ function ConvertTo-GroupObjects {
                 $ggGroup = [ADGroup]::new($Settings.GroupPrefix, $Settings.Environment, $OU.Name, $GroupConfig.Name, "GG", $OU.DistinguishedName, $OU.Domain)
                 $ugGroup.ADGroupMembers += $ggGroup
 
+                # Add Other Groups
+                if ($null -ne $GroupConfig.Groups -and $GroupConfig.Groups.Count -gt 0) {
+                    $GroupConfig.Groups | ForEach-Object {
+                        $groupGroup = [ADGroup]::new($_.DistinguishedName, $_.Domain)
+                        if (Check-GroupExists $groupGroup) {
+                            $ugGroup.ADGroupMembers += $groupGroup
+                        }
+                    }
+                }
+
                 $groups += $ugGroup
                 $groups += $ggGroup
             }
 
             #Add users
-            if ($GroupConfig.Users -ne $null -and $GroupConfig.Users.Count -gt 0) { 
-                $GroupConfig.Users | Where {$_.Domain -eq $OU.Domain.FQDN} | ForEach-Object {
+            if ($null -ne $GroupConfig.Users -and $GroupConfig.Users.Count -gt 0) { 
+                $GroupConfig.Users | Where-Object {$_.Domain -eq $OU.Domain.FQDN} | ForEach-Object {
                     $ggGroup.UserAccountMembers += ConvertTo-UserObject -UserConfig $_ -Domain $OU.Domain
                 }                
-            }        
+            }
+                   
 
             [ADGroup[]]$groups
         }

--- a/UKHO.ADM/internal/ConvertTo-GroupObjects.ps1
+++ b/UKHO.ADM/internal/ConvertTo-GroupObjects.ps1
@@ -21,14 +21,7 @@ function ConvertTo-GroupObjects {
                 $dlGroup.ADGroupMembers += $ggGroup
 
                 # Add Other Groups
-                if ($null -ne $GroupConfig.Groups -and $GroupConfig.Groups.Count -gt 0) {
-                    $GroupConfig.Groups | ForEach-Object {
-                        $groupGroup = [ADGroup]::new($_.DistinguishedName, $OU.Domain)
-                        if (Check-GroupExists $groupGroup) {
-                            $dlGroup.ADGroupMembers += $groupGroup
-                        }
-                    }
-                }
+                Get-NonADMGeneratedGroup -OU $OU -GroupConfig $GroupConfig -ggGroup $ggGroup
 
                 $groups += $dlGroup
                 $groups += $ggGroup
@@ -39,14 +32,7 @@ function ConvertTo-GroupObjects {
                 $ugGroup.ADGroupMembers += $ggGroup
 
                 # Add Other Groups
-                if ($null -ne $GroupConfig.Groups -and $GroupConfig.Groups.Count -gt 0) {
-                    $GroupConfig.Groups | ForEach-Object {
-                        $groupGroup = [ADGroup]::new($_.DistinguishedName, $_.Domain)
-                        if (Check-GroupExists $groupGroup) {
-                            $ugGroup.ADGroupMembers += $groupGroup
-                        }
-                    }
-                }
+                Get-NonADMGeneratedGroup -OU $OU -GroupConfig $GroupConfig -ggGroup $ggGroup
 
                 $groups += $ugGroup
                 $groups += $ggGroup

--- a/UKHO.ADM/internal/Get-NonADMGeneratedGroup.ps1
+++ b/UKHO.ADM/internal/Get-NonADMGeneratedGroup.ps1
@@ -15,13 +15,15 @@ function Get-NonADMGeneratedGroup {
     process {
         if ($null -ne $GroupConfig.Groups -and $GroupConfig.Groups.Count -gt 0) {
             $GroupConfig.Groups | ForEach-Object {
-                $groupGroup = [ADGroup]::new($_.DistinguishedName, $OU.Domain)
-                if (Check-GroupExists $groupGroup) {
-                    Write-Verbose "Adding Group $($groupGroup.DistinguishedName) TO GROUP $($ggGroup.DistinguishedName)"
-                    $ggGroup.ADGroupMembers += $groupGroup
-                }
-                else {
-                    Write-Verbose    "Group $($groupGroup.DistinguishedName) Not found in $($OU.Domain.DistinguishedName)"
+                if ($_.DistinguishedName -like "*$($OU.Domain.DistinguishedName)") {
+                    $groupGroup = [ADGroup]::new($_.DistinguishedName, $OU.Domain)
+                    if (Check-GroupExists $groupGroup) {
+                        Write-Verbose "Adding Group $($groupGroup.DistinguishedName) TO GROUP $($ggGroup.DistinguishedName)"
+                        $ggGroup.ADGroupMembers += $groupGroup
+                    }
+                    else {
+                        Write-Error "Group $($groupGroup.DistinguishedName) Not found in $($OU.Domain.DistinguishedName)"
+                    }
                 }
             }
         }

--- a/UKHO.ADM/internal/Get-NonADMGeneratedGroup.ps1
+++ b/UKHO.ADM/internal/Get-NonADMGeneratedGroup.ps1
@@ -1,0 +1,32 @@
+function Get-NonADMGeneratedGroup {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        $OU,
+        [Parameter(Mandatory)]
+        $GroupConfig,
+        [Parameter(Mandatory)]    
+        $ggGroup
+    )
+    
+    begin {
+    }
+    
+    process {
+        if ($null -ne $GroupConfig.Groups -and $GroupConfig.Groups.Count -gt 0) {
+            $GroupConfig.Groups | ForEach-Object {
+                $groupGroup = [ADGroup]::new($_.DistinguishedName, $OU.Domain)
+                if (Check-GroupExists $groupGroup) {
+                    Write-Verbose "Adding Group $($groupGroup.DistinguishedName) TO GROUP $($ggGroup.DistinguishedName)"
+                    $ggGroup.ADGroupMembers += $groupGroup
+                }
+                else {
+                    Write-Verbose    "Group $($groupGroup.DistinguishedName) Not found in $($OU.Domain.DistinguishedName)"
+                }
+            }
+        }
+    }
+    
+    end {
+    }
+}

--- a/UKHO.ADM/internal/Traverse-Group.ps1
+++ b/UKHO.ADM/internal/Traverse-Group.ps1
@@ -49,7 +49,7 @@ function Traverse-Group {
             }
         }
 
-        foreach ($g in $group.ADGroupMembers) {
+        foreach ($g in $($group.ADGroupMembers | Where-Object ADMGenerated -eq $true) ) {
             $ADChanges = Traverse-Group $g $ADChanges
         }
     }


### PR DESCRIPTION
- if a group exists it will be added as a group in the UG / DL (depending on primary)

- Groups that are created in the scope of the same ADM run are not available to use.